### PR TITLE
pushnateの実装

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -33,8 +33,12 @@ module.exports = {
     link: [
         { rel: 'shortcut icon', href: '/favicon.ico' },
         { rel:'stylesheet', href: 'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css'},
-        { rel:'apple-touch-icon-precomposed', href: 'https://chatbox-inc.com/apple-touch-icon.png'}
-    ]
+        { rel:'apple-touch-icon-precomposed', href: 'https://chatbox-inc.com/apple-touch-icon.png'},
+        { rel:'manifest', href:'/manifest.json'}
+    ],
+    script: [
+      { src: 'https://s.pushnate.com/pushnateWorker.js' }
+    ],
   },
   css: [ ],
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,7 +34,7 @@ module.exports = {
         { rel: 'shortcut icon', href: '/favicon.ico' },
         { rel:'stylesheet', href: 'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css'},
         { rel:'apple-touch-icon-precomposed', href: 'https://chatbox-inc.com/apple-touch-icon.png'},
-        { rel:'manifest', href:'/manifest.json'}
+        { rel:'manifest', href:'/pushnate/manifest.json'}
     ],
     script: [
       { src: 'https://s.pushnate.com/pushnateWorker.js' }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,6 +18,10 @@
   import PageAboutus from '~/components/pages/Index/AboutUs.vue'
   import PageContact from '~/components/pages/Index/Contact.vue'
 
+  // [Pushnate] 実行されたタイミングで、ブラウザのプッシュ通知許可ダイアログが表示
+  // var Pushnate = Pushnate || []
+  // Pushnate.push(["init", { path: "/", site_id: "SDK用ID" }]);
+
   export default {
     components: {
       PageHero,

--- a/pushnate/manifest.json
+++ b/pushnate/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "SiteNameExample",
+  "short_name": "SiteNameExample",
+  "start_url": "/",
+  "display": "standalone",
+  "gcm_sender_id": "GOOGLE_PROJECT_ID",
+  "gcm_user_visible_only": true
+}

--- a/pushnate/manifest.json
+++ b/pushnate/manifest.json
@@ -1,8 +1,8 @@
 {
-  "name": "SiteNameExample",
-  "short_name": "SiteNameExample",
+  "name": "chatbox",
+  "short_name": "chatbox",
   "start_url": "/",
   "display": "standalone",
-  "gcm_sender_id": "GOOGLE_PROJECT_ID",
+  "gcm_sender_id": "GOOGLE_PROJECT_ID", // messagingSenderId
   "gcm_user_visible_only": true
 }

--- a/pushnate/pushnateSDK.js
+++ b/pushnate/pushnateSDK.js
@@ -1,0 +1,1 @@
+importScripts('https://s.pushnate.com/pushnateWorker.js');


### PR DESCRIPTION
- 「設置ディレクトリはルートディレクトリを推奨しています。」と書いていたのでルートディレクトリにpushnateフォルダを設置。

**試したこと**
- ngrokを使ってローカルをsslに対応させ、サイトのURLを変更したが、通知が来ない。
- ボタンを押下時に`Pushnate.push(["init", { path: "/", site_id: "*****" }]);`が実行させるようにしたが、通知が来ない。
- `site_id`や`gcm_sender_id`が間違っていないか確認。
- nuxt.config.js内の`<link>`のURLが間違っていないか確認。